### PR TITLE
Set `module` key in `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "test:types": "tsc --noEmit"
   },
   "files": ["./dist/"],
+  "module": "./dist/index.js",
   "exports": {
     ".": {
       "default": "./dist/index.js",


### PR DESCRIPTION
Fix for projects that are consuming this dependency and are using the `eslint-plugin-import` plugin.

https://github.com/import-js/eslint-plugin-import/issues/1810